### PR TITLE
Endless loop on broken images

### DIFF
--- a/EXIF.py
+++ b/EXIF.py
@@ -1730,8 +1730,7 @@ def process_file(f, stop_tag='UNDEF', details=True, strict=False, debug=False):
                     if debug: print "Increment base by",ord(data[base+2])*256+ord(data[base+3])+2
                 except: pass
                 try: base=base+ord(data[base+2])*256+ord(data[base+3])+2
-                except: pass
-
+                except: return {}
         f.seek(base+12)
         if data[2+base] == '\xFF' and data[6+base:10+base] == 'Exif':
             # detected EXIF header


### PR DESCRIPTION
I've experienced an endless loop with some images. I nailed it down to the exception handling in line 1733. I've changed that line to exit the function instead of trying again. That fixed the endless loop, at least for me.

I've added the broken images I had to deal with into the branch "[broken-images](https://github.com/mibe/exif-py/tree/broken-images)" in my fork.

Here's my script I tested the change with:

``` python
import EXIF
import os

dir = "my_directory"

for root, dirs, files in os.walk(dir):
    for name in files:
        file = os.path.join(dir, name)
        print "Loading {0}".format(file)
        f = open(file, 'rb')
        tags = EXIF.process_file(f)
        for tag in tags.keys():
         if tag not in ('JPEGThumbnail', 'TIFFThumbnail', 'Filename', 'EXIF MakerNote'):
             print "Key: %s, value %s" % (tag, tags[tag])
        f.close()
```
