### PR TITLE
Adding a missing tag from the Exif IFD

### DIFF
--- a/exifread/tags.py
+++ b/exifread/tags.py
@@ -309,6 +309,7 @@ EXIF_TAGS = {
               2: 'Hard'}),
     0xA40B: ('DeviceSettingDescription', ),
     0xA40C: ('SubjectDistanceRange', ),
+    0xA420: ('ImageUniqueID', ),
     0xA500: ('Gamma', ),
     0xC4A5: ('PrintIM', ),
     0xEA1C: ('Padding', ),


### PR DESCRIPTION
In the process of parsing and finding duplicate images in a huge library; I came across an Exif tag which could be used to properly identify unique images, in cases where a SHA-256 sum does not help due to differing metadata. The tag in question is 0xA420 (ImageUniqueID) and it is basically a 128-bit ASCII string generated by the device.

For more information on the tag, read: http://www.awaresystems.be/imaging/tiff/tifftags/privateifd/exif/imageuniqueid.html
