### PR TITLE
Fixing issue #20- "global name 'Ratio' is not defined, happened after EXIF.py is split into several modules"

### DIFF
--- a/exifread/tags/makernote.py
+++ b/exifread/tags/makernote.py
@@ -1,5 +1,6 @@
 
 from .utils import make_string, make_string_uc
+from exifread.classes import Ratio
 
 def nikon_ev_bias(seq):
     """


### PR DESCRIPTION
Import was missing.
