### PR TITLE
EXIF.py crashes on Python3

### DIFF
--- a/EXIF.py
+++ b/EXIF.py
@@ -112,7 +112,7 @@ def main():
             logger.info('File has TIFF thumbnail')
             del data['TIFFThumbnail']
 
-        tag_keys = data.keys()
+        tag_keys = list(data.keys())
         tag_keys.sort()
 
         for i in tag_keys:


### PR DESCRIPTION
EXIF.py tries to sort the output of {}.keys()
On Python2, {}.keys() returns a list
On Python3, {}.keys() returns a dict_keys, without a .sort() method

Wrapping the {}.keys() in list() seems to solve the problem. No negative side-effects noticed or expected.
