### PR TITLE
Use the built-in Fraction class

### DIFF
--- a/exifread/utils.py
+++ b/exifread/utils.py
@@ -2,6 +2,8 @@
 Misc utilities.
 """
 
+from fractions import Fraction
+
 
 def ord_(dta):
     if isinstance(dta, str):
@@ -56,31 +58,15 @@ def s2n_intel(string):
     return x
 
 
-class Ratio:
-    """
-    Ratio object that eventually will be able to reduce itself to lowest
-    common denominator for printing.
-    """
+class Ratio(Fraction):
+    @property
+    def num(self):
+        return self.numerator
 
-    def __init__(self, num, den):
-        self.num = num
-        self.den = den
+    @property
+    def den(self):
+        return self.denominator
 
     def __repr__(self):
-        self.reduce()
-        if self.den == 1:
-            return str(self.num)
-        return '%d/%d' % (self.num, self.den)
-
-    def _gcd(self, a, b):
-        if b == 0:
-            return a
-        else:
-            return self._gcd(b, a % b)
-
-    def reduce(self):
-        div = self._gcd(self.num, self.den)
-        if div > 1:
-            self.num = self.num // div
-            self.den = self.den // div
+        return str(self)
 

--- a/exifread/utils.py
+++ b/exifread/utils.py
@@ -40,24 +40,6 @@ def make_string_uc(seq):
     return make_string(seq)
 
 
-def s2n_motorola(string):
-    """Extract multi-byte integer in Motorola format (little endian)."""
-    x = 0
-    for c in string:
-        x = (x << 8) | ord_(c)
-    return x
-
-
-def s2n_intel(string):
-    """Extract multi-byte integer in Intel format (big endian)."""
-    x = 0
-    y = 0
-    for c in string:
-        x = x | (ord_(c) << y)
-        y += + 8
-    return x
-
-
 class Ratio(Fraction):
     @property
     def num(self):


### PR DESCRIPTION
Instead of defining our own Ratio class, just use the built-in Fraction
class instead (which means we inherit the ability to use the fraction
with normal arithmetic operators). This modification re-defines the
Ratio class as a subclass of Fraction which adds den and num as
calculated properties for backwards compatibility (the representation is
also overridden to maintain compatibility).