### PR TITLE
Use struct for all packing/unpacking

### DIFF
--- a/exifread/classes.py
+++ b/exifread/classes.py
@@ -2,7 +2,7 @@ import struct
 import re
 
 from .exif_log import get_logger
-from .utils import s2n_motorola, s2n_intel, Ratio
+from .utils import Ratio
 from .tags import *
 
 logger = get_logger()
@@ -61,7 +61,7 @@ class ExifHeader:
         self.detailed = detailed
         self.tags = {}
 
-    def s2n(self, offset, length, signed=0):
+    def s2n(self, offset, length, signed=False):
         """
         Convert slice to integer, based on sign and endian flags.
 
@@ -70,18 +70,28 @@ class ExifHeader:
         For some cameras that use relative tags, this offset may be relative
         to some other starting point.
         """
+        # Little-endian if Intel, big-endian if Motorola
+        fmt = '<' if self.endian == 'I' else '>'
+        # Construct a format string from the requested length and signedness;
+        # raise a ValueError if length is something silly like 3
+        try:
+            fmt += {
+                (1, False): 'B',
+                (1, True):  'b',
+                (2, False): 'H',
+                (2, True):  'h',
+                (4, False): 'I',
+                (4, True):  'i',
+                (8, False): 'L',
+                (8, True):  'l',
+                }[(length, signed)]
+        except KeyError:
+            raise ValueError('unexpected unpacking length: %d' % length)
         self.file.seek(self.offset + offset)
-        sliced = self.file.read(length)
-        if self.endian == 'I':
-            val = s2n_intel(sliced)
-        else:
-            val = s2n_motorola(sliced)
-            # Sign extension?
-        if signed:
-            msb = 1 << (8 * length - 1)
-            if val & msb:
-                val -= (msb << 1)
-        return val
+        buf = self.file.read(length)
+        if buf:
+            return struct.unpack(fmt, buf)[0]
+        return 0
 
     def n2s(self, offset, length):
         """Convert offset to string."""

--- a/exifread/utils.py
+++ b/exifread/utils.py
@@ -38,24 +38,6 @@ def make_string_uc(seq):
     return make_string(seq)
 
 
-def s2n_motorola(string):
-    """Extract multi-byte integer in Motorola format (little endian)."""
-    x = 0
-    for c in string:
-        x = (x << 8) | ord_(c)
-    return x
-
-
-def s2n_intel(string):
-    """Extract multi-byte integer in Intel format (big endian)."""
-    x = 0
-    y = 0
-    for c in string:
-        x = x | (ord_(c) << y)
-        y += + 8
-    return x
-
-
 class Ratio:
     """
     Ratio object that eventually will be able to reduce itself to lowest


### PR DESCRIPTION
No sense defining our own "s2n" routines when struct does everything required (and much faster); this commit also corrects the comments regarding Intel and Motorola endianness (Intel is little, Motorola is
big)
