### PR TITLE
Use struct for unpack (and add support for floats)

### DIFF
--- a/exifread/classes.py
+++ b/exifread/classes.py
@@ -2,7 +2,7 @@ import struct
 import re
 
 from .exif_log import get_logger
-from .utils import s2n_motorola, s2n_intel, Ratio
+from .utils import Ratio
 from .tags import *
 
 logger = get_logger()
@@ -61,7 +61,7 @@ class ExifHeader:
         self.detailed = detailed
         self.tags = {}
 
-    def s2n(self, offset, length, signed=0):
+    def s2n(self, offset, length, signed=False):
         """
         Convert slice to integer, based on sign and endian flags.
 
@@ -70,18 +70,28 @@ class ExifHeader:
         For some cameras that use relative tags, this offset may be relative
         to some other starting point.
         """
+        # Little-endian if Intel, big-endian if Motorola
+        fmt = '<' if self.endian == 'I' else '>'
+        # Construct a format string from the requested length and signedness;
+        # raise a ValueError if length is something silly like 3
+        try:
+            fmt += {
+                (1, False): 'B',
+                (1, True):  'b',
+                (2, False): 'H',
+                (2, True):  'h',
+                (4, False): 'I',
+                (4, True):  'i',
+                (8, False): 'L',
+                (8, True):  'l',
+                }[(length, signed)]
+        except KeyError:
+            raise ValueError('unexpected unpacking length: %d' % length)
         self.file.seek(self.offset + offset)
-        sliced = self.file.read(length)
-        if self.endian == 'I':
-            val = s2n_intel(sliced)
-        else:
-            val = s2n_motorola(sliced)
-            # Sign extension?
-        if signed:
-            msb = 1 << (8 * length - 1)
-            if val & msb:
-                val -= (msb << 1)
-        return val
+        buf = self.file.read(length)
+        if buf:
+            return struct.unpack(fmt, buf)[0]
+        return 0
 
     def n2s(self, offset, length):
         """Convert offset to string."""

--- a/exifread/utils.py
+++ b/exifread/utils.py
@@ -38,24 +38,6 @@ def make_string_uc(seq):
     return make_string(seq)
 
 
-def s2n_motorola(string):
-    """Extract multi-byte integer in Motorola format (little endian)."""
-    x = 0
-    for c in string:
-        x = (x << 8) | ord_(c)
-    return x
-
-
-def s2n_intel(string):
-    """Extract multi-byte integer in Intel format (big endian)."""
-    x = 0
-    y = 0
-    for c in string:
-        x = x | (ord_(c) << y)
-        y += + 8
-    return x
-
-
 class Ratio:
     """
     Ratio object that eventually will be able to reduce itself to lowest

--- a/exifread/utils.py
+++ b/exifread/utils.py
@@ -53,6 +53,9 @@ class Ratio:
         if self.den == 1:
             return str(self.num)
         return '%d/%d' % (self.num, self.den)
+    
+    def __float__(self):
+        return ((1.0*self.num)/self.den)
 
     def _gcd(self, a, b):
         if b == 0:


### PR DESCRIPTION
Adding support for floating point fields for both single and double precision. If you're avoiding waveform80's struct refactor for some reason, commit 2f0bcb721a877c82ca7d420dbe9544cf8295f5b2 was based on ianare's development, then merged with waveform80's branch, so you can still get the floating point functionality without waveform80's stuff. Not sure why you would, though.
