### PR TITLE
Add option to prevent truncation of tags.

### DIFF
--- a/exifread/__init__.py
+++ b/exifread/__init__.py
@@ -16,7 +16,7 @@ def increment_base(data, base):
     return ord_(data[base + 2]) * 256 + ord_(data[base + 3]) + 2
 
 
-def process_file(f, stop_tag=DEFAULT_STOP_TAG, details=True, strict=False, debug=False):
+def process_file(f, stop_tag=DEFAULT_STOP_TAG, details=True, strict=False, debug=False, truncate_tags=True):
     """
     Process an image file (expects an open file object).
 
@@ -188,7 +188,7 @@ def process_file(f, stop_tag=DEFAULT_STOP_TAG, details=True, strict=False, debug
         'd': 'XMP/Adobe unknown'
     }[endian])
 
-    hdr = ExifHeader(f, endian, offset, fake_exif, strict, debug, details)
+    hdr = ExifHeader(f, endian, offset, fake_exif, strict, debug, details, truncate_tags)
     ifd_list = hdr.list_ifd()
     thumb_ifd = False
     ctr = 0

--- a/exifread/classes.py
+++ b/exifread/classes.py
@@ -53,9 +53,8 @@ class ExifHeader:
     """
     Handle an EXIF header.
     """
-
     def __init__(self, file, endian, offset, fake_exif, strict,
-                 debug=False, detailed=True):
+                 debug=False, detailed=True, truncate_tags=True):
         self.file = file
         self.endian = endian
         self.offset = offset
@@ -63,6 +62,7 @@ class ExifHeader:
         self.strict = strict
         self.debug = debug
         self.detailed = detailed
+        self.truncate_tags = truncate_tags
         self.tags = {}
 
     def s2n(self, offset, length, signed=0):
@@ -231,7 +231,10 @@ class ExifHeader:
                 if count == 1 and field_type != 2:
                     printable = str(values[0])
                 elif count > 50 and len(values) > 20 and not isinstance(values, basestring) :
-                    printable = str(values[0:20])[0:-1] + ", ... ]"
+                    if self.truncate_tags :
+                        printable = str(values[0:20])[0:-1] + ", ... ]"
+                    else:
+                        printable = str(values[0:-1])
                 else:
                     try:
                         printable = str(values)


### PR DESCRIPTION
Add a passable option, truncate_tags, to prevent EXIF tags from being truncated
to 20 characters. The current implementation truncated to 20 characters and
ended with an ellipsis, ... . However, this could cause problems for calling
functions. Therefore, setting truncate_tags to false (default true) passes the
entire tag.