### PR TITLE
Handle case where string count is 0

### DIFF
--- a/exifread/classes.py
+++ b/exifread/classes.py
@@ -188,7 +188,7 @@ class ExifHeader:
                         try:
                             self.file.seek(file_position)
                             values = self.file.read(count)
-                            #print(values)
+
                             # Drop any garbage after a null.
                             values = values.split(b'\x00', 1)[0]
                             if isinstance(values, bytes):
@@ -202,6 +202,8 @@ class ExifHeader:
                         except MemoryError:
                             logger.warn('MemoryError at position: %s, length: %s', file_position, count)
                             values = ''
+                    else:
+                        values = ''
                 else:
                     values = []
                     signed = (field_type in [6, 8, 9, 10])


### PR DESCRIPTION
I've run into files with entries of `field_type==2` and `count==0`. That case is not currently handled.

Since the default `values` is `None`, parsing breaks when trying to convert the value to something printable.

Setting `values` to an empty string fixes it.

Here's a test image
![test](https://cloud.githubusercontent.com/assets/841954/21392666/42fa9d5c-c791-11e6-95a3-428085a28832.jpg)

