### PR TITLE
utils.py: make Ratio() return for denominator != 0

### DIFF
--- a/exifread/utils.py
+++ b/exifread/utils.py
@@ -81,7 +81,7 @@ class Ratio(Fraction):
             self = super(Ratio, cls).__new__(cls)
             self._numerator = numerator
             self._denominator = denominator
-            return self
+        return self
     __new__.doc = Fraction.__new__.__doc__
 
     def __repr__(self):


### PR DESCRIPTION
May have been due to an accidental extra indent before the `return` statement.

Fixes #96