### PR TITLE
Use list instead of tuple for classifiers

### DIFF
--- a/exifread/__init__.py
+++ b/exifread/__init__.py
@@ -8,7 +8,7 @@ from .tags import *
 from .utils import ord_
 from .heic import HEICExifFinder
 
-__version__ = '2.1.2'
+__version__ = '2.2.0'
 
 logger = get_logger()
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     keywords="exif image metadata photo",
     description=" ".join(exifread.__doc__.splitlines()).strip(),
     long_description=readme_file,
-    classifiers=(
+    classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",
         "Intended Audience :: Developers",
@@ -30,5 +30,5 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Topic :: Utilities",
-    ),
+    ],
 )


### PR DESCRIPTION
This avoids a warning in `python setup.py sdist`.