### PR TITLE
Add black level tag

### DIFF
--- a/exifread/tags/exif.py
+++ b/exifread/tags/exif.py
@@ -438,4 +438,6 @@ EXIF_TAGS = {
     0xEA1D: ('OffsetSchema', ),
     0xFDE8: ('OwnerName', ),
     0xFDE9: ('SerialNumber', ),
+    0xC61A: ('BlackLevel', ),
+
 }


### PR DESCRIPTION
Hello :hand:

Noticed during development that the "BlackLevel" tag shows up as "Image Tag 0xC61A".

Thought I'd add it to the list (not sure that's the correct place).

Hope this can be helpful?

