### PR TITLE
Adding Python 3.8 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 install:
   - "pip install ."


### PR DESCRIPTION
Python 3.8 has been released in October 2019 and it is expected that security updates until approximately October 2024.

See [PEP 569 -- Python 3.8 Release Schedule](https://www.python.org/dev/peps/pep-0569/) 