### PR TITLE
Added missing Ifd data type

### DIFF
--- a/exifread/classes.py
+++ b/exifread/classes.py
@@ -193,7 +193,7 @@ class ExifHeader:
                     # special case: null-terminated ASCII string
                     # XXX investigate
                     # sometimes gets too big to fit in int value
-                    if count != 0:  # and count < (2**31):  # 2E31 is hardware dependant. --gd
+                    if count != 0:  # and count < (2**31):  # 2E31 is hardware dependent. --gd
                         file_position = self.offset + offset
                         try:
                             self.file.seek(file_position)

--- a/exifread/tags/__init__.py
+++ b/exifread/tags/__init__.py
@@ -22,6 +22,7 @@ FIELD_TYPES = (
     (8, 'SR', 'Signed Ratio'),
     (4, 'F32', 'Single-Precision Floating Point (32-bit)'),
     (8, 'F64', 'Double-Precision Floating Point (64-bit)'),
+    (4, 'L', 'IFD'),
 )
 
 # To ignore when quick processing


### PR DESCRIPTION
Hello :hand:

This PR adds support for a missing IFD data type.

The values come from https://clanmills.com/exiv2/book/#8-3 (lead developer of exiv2). 

![image](https://user-images.githubusercontent.com/1951843/87947804-db71b980-ca71-11ea-922b-f69b0dc70f31.png)

In my case it fixed a problem while reading GPSInfo tags from an image.

