### PR TITLE
Add missing EXIF OffsetTime tags

### DIFF
--- a/exifread/tags/exif.py
+++ b/exifread/tags/exif.py
@@ -258,6 +258,9 @@ EXIF_TAGS = {
     0x9000: ('ExifVersion', make_string),
     0x9003: ('DateTimeOriginal', ),
     0x9004: ('DateTimeDigitized', ),
+    0x9010: ('OffsetTime', ),
+    0x9011: ('OffsetTimeOriginal', ),
+    0x9012: ('OffsetTimeDigitized', ),
     0x9101: ('ComponentsConfiguration', {
         0: '',
         1: 'Y',


### PR DESCRIPTION
The OffsetTime EXIF tags are missing from the library (ending up being parsed as "EXIF Tag 0x9010" instead of the proper name).
From https://exiftool.org/TagNames/EXIF.html:
![image](https://user-images.githubusercontent.com/16963011/95664709-5c43cd00-0b18-11eb-980b-97a1292203b4.png)

# :snake: :man_juggling: 
