### PR TITLE
Update make_string util to clean up bad values

### DIFF
--- a/exifread/tags/__init__.py
+++ b/exifread/tags/__init__.py
@@ -27,7 +27,7 @@ FIELD_TYPES = (
 
 # To ignore when quick processing
 IGNORE_TAGS = (
-    0x9286,  # user comment
-    0x927C,  # MakerNote Tags
     0x02BC,  # XPM
+    0x927C,  # MakerNote Tags
+    0x9286,  # user comment
 )

--- a/exifread/tags/exif.py
+++ b/exifread/tags/exif.py
@@ -437,10 +437,9 @@ EXIF_TAGS = {
     0xA435: ('LensSerialNumber', ),
     0xA500: ('Gamma', ),
     0xC4A5: ('PrintIM', ),
+    0xC61A: ('BlackLevel', ),
     0xEA1C: ('Padding', ),
     0xEA1D: ('OffsetSchema', ),
     0xFDE8: ('OwnerName', ),
     0xFDE9: ('SerialNumber', ),
-    0xC61A: ('BlackLevel', ),
-
 }

--- a/exifread/tags/makernote/nikon.py
+++ b/exifread/tags/makernote/nikon.py
@@ -52,7 +52,7 @@ def ev_bias(seq) -> str:
 # Nikon E99x MakerNote Tags
 TAGS_NEW = {
     0x0001: ('MakernoteVersion', make_string),  # Sometimes binary
-    0x0002: ('ISOSetting', make_string),
+    0x0002: ('ISOSetting', ),
     0x0003: ('ColorMode', ),
     0x0004: ('Quality', ),
     0x0005: ('Whitebalance', ),

--- a/exifread/utils.py
+++ b/exifread/utils.py
@@ -3,6 +3,7 @@ Misc utilities.
 """
 
 from fractions import Fraction
+from typing import Union
 
 
 def ord_(dta):
@@ -11,7 +12,7 @@ def ord_(dta):
     return dta
 
 
-def make_string(seq: bytes) -> str:
+def make_string(seq: Union[bytes, list]) -> str:
     """
     Don't throw an exception when given an out of range character.
     """
@@ -23,10 +24,19 @@ def make_string(seq: bytes) -> str:
                 string += chr(char)
         except TypeError:
             pass
+
     # If no printing chars
     if not string:
-        return str(seq)
-    return string
+        if isinstance(seq, list):
+            string = ''.join(map(str, seq))
+            # Some UserComment lists only contain null bytes, nothing valueable to return
+            if set(string) == {'0'}:
+                return ''
+        else:
+            string = str(seq)
+
+    # Clean undesirable characters on any end
+    return string.strip(' \x00')
 
 
 def make_string_uc(seq) -> str:


### PR DESCRIPTION
From exif-samples-master, the type of the seq arguments for a few entries (mostly UserComment) in util.make_string is a list. mypy still succeeds after the type annotation amendment. There is also no value in keeping a list of null bytes.

On another note, many other UserComment only contain spaces and some other fields contained trailing spaces (seen null character as well).

Finally, Nikon MakerNote ISOSetting is int16u[2] and should not be stringified. https://exiftool.org/TagNames/Nikon.html Sample values seen include [0, 0] and [0, 200], which were respectively being converted to '[0, 0]' and '}' by make_string.

The test diff output does not clearly show the effect of `.strip()`, so here it is along one example of the printable value of the IfdTag:
```diff
-  "EXIF UserComment": "                                                                                                                     ",
+  "EXIF UserComment": "",
```

```diff
$ diff -y --suppress-common-lines exif-samples-master/dump exif-samples-master/dump_test
EXIF UserComment (Undefined): [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined): [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined): [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined): [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined): [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined): [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined): [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
MakerNote MakernoteVersion (Undefined): [0, 2, 0, 0]          | MakerNote MakernoteVersion (Undefined): 0200
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined): [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined): [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined): [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined): [0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  | EXIF UserComment (Undefined): 
EXIF UserComment (Undefined):                                 | EXIF UserComment (Undefined): 
```

@ianare, if you approve this PR, I can modify the exif-sample-master/dump afterwards to reflect changes :)

# :snake: :man_juggling: 