### PR TITLE
Remove coding system from UserComment sequence only if it is valid

### DIFF
--- a/exifread/utils.py
+++ b/exifread/utils.py
@@ -45,7 +45,9 @@ def make_string_uc(seq) -> str:
     First 8 bytes gives coding system e.g. ASCII vs. JIS vs Unicode.
     """
     if not isinstance(seq, str):
-        seq = seq[8:]
+        # Remove code from sequence only if it is valid
+        if make_string(seq[:8]).upper() in ('ASCII', 'UNICODE', 'JIS', ''):
+            seq = seq[8:]
     # Of course, this is only correct if ASCII, and the standard explicitly
     # allows JIS and Unicode.
     return make_string(seq)


### PR DESCRIPTION
Behavior is similar like in exiftool package (https://github.com/exiftool/exiftool/blob/master/lib/Image/ExifTool/Exif.pm#L5025) if coding system is not valid, show warning but pass all sequnce further