### PR TITLE
fix readme exaple error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,11 +167,11 @@ This example shows how to use the library to correct the orientation of an image
     def _read_img_and_correct_exif_orientation(path):
         im = Image.open(path)
         tags = {}
-        logging.basicConfig(level=logging.DEBUG)
         with open(path, 'rb') as f:
             tags = exifread.process_file(f, details=False)
         if "Image Orientation" in tags.keys():
             orientation = tags["Image Orientation"]
+            logging.basicConfig(level=logging.DEBUG)
             logging.debug("Orientation: %s (%s)", orientation, orientation.values)
             val = orientation.values
             if 5 in val:

--- a/README.rst
+++ b/README.rst
@@ -161,11 +161,13 @@ This example shows how to use the library to correct the orientation of an image
 .. code-block:: python
 
     import exifread
-    from Pillow import Image
+    from PIL import Image
+    import logging
     
     def _read_img_and_correct_exif_orientation(path):
         im = Image.open(path)
         tags = {}
+        logging.basicConfig(level=logging.DEBUG)
         with open(path, 'rb') as f:
             tags = exifread.process_file(f, details=False)
         if "Image Orientation" in tags.keys():


### PR DESCRIPTION
Now the example code can print image orientation info to console correctly.