### PR TITLE
HEIC Unknown Parsers

### DIFF
--- a/exifread/heic.py
+++ b/exifread/heic.py
@@ -169,7 +169,7 @@ class HEICExifFinder:
         }
         try:
             return defs[box.name]
-        except IndexError as err:
+        except (IndexError, KeyError) as err:
             raise NoParser(box.name) from err
 
     def parse_box(self, box: Box) -> Box:


### PR DESCRIPTION
This is for HEIC handler raising a KeyError instead of an IndexError when it comes to handling unknown parsers.