### PR TITLE
Fix a minor typo in usage example in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -175,9 +175,9 @@ This example shows how to use the library to correct the orientation of an image
             logging.debug("Orientation: %s (%s)", orientation, orientation.values)
             val = orientation.values
             if 5 in val:
-                val += [4,8]
-            if 7 in val:
                 val += [4, 6]
+            if 7 in val:
+                val += [4, 8]
             if 3 in val:
                 logging.debug("Rotating by 180 degrees.")
                 im = im.transpose(Image.ROTATE_180)


### PR DESCRIPTION
The code for usage example has a minor bug for orientation values 5 and 7.
- A 5 orientation value needs to be flipped top-to-bottom (a 4 operation) and then rotate 270 CCW (a 6 operation)
- A 7 orientation value needs to be flipped top-to-bottom (a 4 operation) and then rotate 90 CCW (a 8 operation)