### PR TITLE
fix struct.error if buf less than 2

### DIFF
--- a/exifread/classes.py
+++ b/exifread/classes.py
@@ -97,9 +97,13 @@ class ExifHeader:
             raise ValueError('unexpected unpacking length: %d' % length) from err
         self.file_handle.seek(self.offset + offset)
         buf = self.file_handle.read(length)
+    
         if buf:
-            return struct.unpack(fmt, buf)[0]
+            if len(buf) >= 2:
+                return struct.unpack(fmt, buf)[0]
+            return 0
         return 0
+    
 
     def n2b(self, offset, length) -> bytes:
         """Convert offset to bytes."""


### PR DESCRIPTION
Function `exifread.process_file(image)` didnt work for some images with corrupted exif info. To put it to work I set an extra check: if **buf** variable exist we need to check that length of buf more than 1. Because if **buf** equals 1 function gives error "struct.error: unpack requires a buffer of 2 bytes" and function stop iterating to next files.