### PR TITLE
fix cycle in list ifd, fix #161

### DIFF
--- a/exifread/classes.py
+++ b/exifread/classes.py
@@ -132,7 +132,12 @@ class ExifHeader:
         """Return the list of IFDs in the header."""
         i = self._first_ifd()
         ifds = []
+        set_ifds = set()
         while i:
+            if i in set_ifds:
+                logger.warning('IFD loop detected.')
+                break
+            set_ifds.add(i)
             ifds.append(i)
             i = self._next_ifd(i)
         return ifds


### PR DESCRIPTION
In some rare case (see #161), there can be a cycle in the ifd, resulting in an infinite loop when trying to extract the exif of an image
this fixes this problem