### PR TITLE
Add DJI makernotes, extract_thumbnail parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ Pass the ``-q`` or ``--quick`` command line arguments, or as:
 
     tags = exifread.process_file(f, details=False)
 
-To process makernotes only, without extract the thumbnail image (if any):
+To process makernotes only, without extracting the thumbnail image (if any):
 
 .. code-block:: python
     tags = exifread.process_file(f, details=True, extract_thumbnail=False)

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,7 @@ Pass the ``-q`` or ``--quick`` command line arguments, or as:
 To process makernotes only, without extracting the thumbnail image (if any):
 
 .. code-block:: python
+
     tags = exifread.process_file(f, details=True, extract_thumbnail=False)
 
 Stop at a Given Tag

--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,11 @@ Pass the ``-q`` or ``--quick`` command line arguments, or as:
 
     tags = exifread.process_file(f, details=False)
 
+To process makernotes only, without extract the thumbnail image (if any):
+
+.. code-block:: python
+    tags = exifread.process_file(f, details=True, extract_thumbnail=False)
+
 Stop at a Given Tag
 ===================
 

--- a/exifread/__init__.py
+++ b/exifread/__init__.py
@@ -122,7 +122,7 @@ def _determine_type(fh: BinaryIO) -> tuple:
 
 def process_file(fh: BinaryIO, stop_tag=DEFAULT_STOP_TAG,
                  details=True, strict=False, debug=False,
-                 truncate_tags=True, auto_seek=True):
+                 truncate_tags=True, auto_seek=True, extract_thumbnail=True):
     """
     Process an image file (expects an open file object).
 
@@ -179,7 +179,7 @@ def process_file(fh: BinaryIO, stop_tag=DEFAULT_STOP_TAG,
         hdr.decode_maker_note()
 
     # extract thumbnails
-    if details and thumb_ifd:
+    if details and thumb_ifd and extract_thumbnail:
         hdr.extract_tiff_thumbnail(thumb_ifd)
         hdr.extract_jpeg_thumbnail()
 

--- a/exifread/classes.py
+++ b/exifread/classes.py
@@ -496,7 +496,14 @@ class ExifHeader:
             self.dump_ifd(0, 'MakerNote', tag_dict=makernote.apple.TAGS)
             self.offset = offset
             return
-
+        
+        if make == 'DJI':
+            offset = self.offset
+            self.offset += note.field_offset
+            self.dump_ifd(0, 'MakerNote', tag_dict=makernote.dji.TAGS)
+            self.offset = offset
+            return
+        
         # Canon
         if make == 'Canon':
             self.dump_ifd(note.field_offset, 'MakerNote',

--- a/exifread/tags/__init__.py
+++ b/exifread/tags/__init__.py
@@ -4,7 +4,7 @@ Tag definitions
 
 from exifread.tags.exif import EXIF_TAGS
 from exifread.tags.makernote import (
-    apple, canon, casio, fujifilm, nikon, olympus,
+    apple, canon, casio, fujifilm, nikon, olympus, dji
 )
 
 DEFAULT_STOP_TAG = 'UNDEF'

--- a/exifread/tags/makernote/dji.py
+++ b/exifread/tags/makernote/dji.py
@@ -1,0 +1,17 @@
+"""
+Makernote (proprietary) tag definitions for DJI cameras
+
+Based on https://github.com/exiftool/exiftool/blob/master/lib/Image/ExifTool/DJI.pm
+"""
+
+TAGS = {
+    0x03: ('SpeedX', ),
+    0x04: ('SpeedY', ),
+    0x05: ('SpeedZ', ),
+    0x06: ('Pitch', ),
+    0x07: ('Yaw', ),
+    0x08: ('Roll', ),
+    0x09: ('CameraPitch', ),
+    0x0a: ('CameraYaw', ),
+    0x0b: ('CameraRoll', ),
+}


### PR DESCRIPTION
Hello :hand: 

This PR adds support for reading makernotes from DJI cameras.

I've also added a `extract_thumbnail` parameter to `process_file`, sometimes it might be useful to extract makernotes but one is not interested in extracting thumbnails, so it speeds up processing a little bit for this scenario (not sure this is the best approach here).

Hope this can be useful to others.﻿
