### PR TITLE
Allow extract thumbnail with details=False

### DIFF
--- a/EXIF.py
+++ b/EXIF.py
@@ -6,7 +6,7 @@
 #
 #
 # Copyright (c) 2002-2007 Gene Cash
-# Copyright (c) 2007-2022 Ianaré Sévi and contributors
+# Copyright (c) 2007-2023 Ianaré Sévi and contributors
 #
 # See LICENSE.txt file for licensing information
 # See ChangeLog.rst file for all contributors and changes
@@ -25,7 +25,7 @@ from exifread import process_file, exif_log, __version__
 logger = exif_log.get_logger()
 
 
-def get_args():
+def get_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog='EXIF.py',
         description='Extract EXIF information from digital image files.'
@@ -41,7 +41,7 @@ def get_args():
     )
     parser.add_argument(
         '-q', '--quick', action='store_false', dest='detailed',
-        help='Do not process MakerNotes',
+        help='Do not process MakerNotes and do not extract thumbnails',
     )
     parser.add_argument(
         '-t', '--tag', type=str, dest='stop_tag',
@@ -87,7 +87,12 @@ def main(args) -> None:
 
         # get the tags
         data = process_file(
-            img_file, stop_tag=args.stop_tag, details=args.detailed, strict=args.strict, debug=args.debug
+            img_file,
+            stop_tag=args.stop_tag,
+            details=args.detailed,
+            strict=args.strict,
+            debug=args.debug,
+            extract_thumbnail=args.detailed
         )
 
         tag_stop = timeit.default_timer()

--- a/exifread/__init__.py
+++ b/exifread/__init__.py
@@ -180,7 +180,7 @@ def process_file(fh: BinaryIO, stop_tag=DEFAULT_STOP_TAG,
         hdr.decode_maker_note()
 
     # extract thumbnails
-    if details and thumb_ifd and extract_thumbnail:
+    if details or (thumb_ifd and extract_thumbnail):
         hdr.extract_tiff_thumbnail(thumb_ifd)
         hdr.extract_jpeg_thumbnail()
 

--- a/exifread/__init__.py
+++ b/exifread/__init__.py
@@ -116,7 +116,6 @@ def _determine_type(fh: BinaryIO) -> tuple:
     elif data[0:8] == b'\x89PNG\r\n\x1a\n':
         offset, endian = _find_png_exif(fh, data)
     else:
-        # file format not recognized
         raise ExifNotFound("File format not recognized.")
     return offset, endian, fake_exif
 


### PR DESCRIPTION
With this simple modification, it is possible to use details=False, extract_thumbnail=True. Processing 1156 CR2 images on a SD card-on USB card reader takes: details=True, extract_thumbnail=True  (204 s)
details=True, extract_thumbnail=True  (2.67 s)
details=False, extract_thumbnail=True  (2.67 s)

So thumbnail extraction is very fast and should be possible to allow it independent of the detailed tags.