### PR TITLE
HEIC + iPhone: ignore heic boxes

### DIFF
--- a/exifread/heic.py
+++ b/exifread/heic.py
@@ -192,11 +192,12 @@ class HEICExifFinder:
         self.get_full(meta)
         while self.file_handle.tell() < meta.after:
             box = self.next_box()
-            psub = self.get_parser(box)
-            if psub is not None:
+
+            try:
+                psub = self.get_parser(box)
                 psub(box)
                 meta.subs[box.name] = box
-            else:
+            except NoParser as e:
                 logger.debug('HEIC: skipping %r', box)
             # skip any unparsed data
             self.skip(box)


### PR DESCRIPTION
Not sure if this was the intended behavior here as `get_parser` has no flow to return `None`, however, this change worked for me to load iPhone files, hoping it's helpful for someone else.