### PR TITLE
Added missing HEIC box names and handling of a TIFF header inside HEIC

### DIFF
--- a/exifread/__init__.py
+++ b/exifread/__init__.py
@@ -34,11 +34,12 @@ def _find_heic_tiff(fh: BinaryIO) -> tuple:
         offset = fh.tell() - 4
         fh.seek(offset)
         endian = data[0:2]
-        asterisk = data[2:4]
         offset = fh.tell()
-        logger.debug(f'Found TIFF header in Exif, offset = {offset:0x}H')
+        logger.debug('Found TIFF header in Exif, offset = %0xH', offset)
     else:
-        raise InvalidExif("Exif pointer to zeros, but found {data} instead of a TIFF header.")
+        raise InvalidExif(
+            "Exif pointer to zeros, but found " + str(data) + " instead of a TIFF header."
+        )
 
     return offset, endian
 

--- a/exifread/__init__.py
+++ b/exifread/__init__.py
@@ -38,7 +38,7 @@ def _find_heic_tiff(fh: BinaryIO) -> tuple:
         offset = fh.tell()
         logger.debug(f'Found TIFF header in Exif, offset = {offset:0x}H')
     else:
-            raise InvalidExif("Exif pointer to zeros, but found {data} instead of a TIFF header.")
+        raise InvalidExif("Exif pointer to zeros, but found {data} instead of a TIFF header.")
 
     return offset, endian
 

--- a/exifread/heic.py
+++ b/exifread/heic.py
@@ -263,39 +263,36 @@ class HEICExifFinder:
                 extents.append((extent_offset, extent_length))
             box.locs[item_id] = extents
 
-    """ Added a few box names, which as unhandled aborted data extraction:
-          hdlr, pitm, dinf, iprp, idat, iref
-        Handling is initially NONE.
-        They were found in .heif photo files produced by Nokia 8.3 5G.
-        They are part of the standard, referring to:
-            - ISO/IEC 14496-12 fifth edition 2015-02-20 (chapter 8.10 Metadata)
-              found in: https://mpeg.chiariglione.org/standards/mpeg-4/iso-base-media-file-format/text-isoiec-14496-12-5th-edition
-              (The newest is ISO/IEC 14496-12:2022, but would cost 208 Swiss Francs at iso.org)
-            - A C++ example: https://exiv2.org/book/#BMFF
-    """
+    # Added a few box names, which as unhandled aborted data extraction:
+    # hdlr, pitm, dinf, iprp, idat, iref
+    #
+    # Handling is initially `None`.
+    # They were found in .heif photo files produced by Nokia 8.3 5G.
+    #
+    # They are part of the standard, referring to:
+    #   - ISO/IEC 14496-12 fifth edition 2015-02-20 (chapter 8.10 Metadata)
+    #     found in:
+    #     https://mpeg.chiariglione.org/standards/mpeg-4/iso-base-media-file-format/text-isoiec-14496-12-5th-edition
+    #     (The newest is ISO/IEC 14496-12:2022, but would cost 208 Swiss Francs at iso.org)
+    #   - A C++ example: https://exiv2.org/book/#BMFF
+
     def _parse_hdlr(self, box: Box):
-        logger.debug("HEIC: found 'hdlr' Box, skipped")
-        pass
+        logger.debug("HEIC: found 'hdlr' Box %s, skipped", box.name)
 
     def _parse_pitm(self, box: Box):
-        logger.debug("HEIC: found 'pitm' Box, skipped")
-        pass
+        logger.debug("HEIC: found 'pitm' Box %s, skipped", box.name)
 
     def _parse_dinf(self, box: Box):
-        logger.debug("HEIC: found 'dinf' Box, skipped")
-        pass
+        logger.debug("HEIC: found 'dinf' Box %s, skipped", box.name)
 
     def _parse_iprp(self, box: Box):
-        logger.debug("HEIC: found 'iprp' Box, skipped")
-        pass
+        logger.debug("HEIC: found 'iprp' Box %s, skipped", box.name)
 
     def _parse_idat(self, box: Box):
-        logger.debug("HEIC: found 'idat' Box, skipped")
-        pass
+        logger.debug("HEIC: found 'idat' Box %s, skipped", box.name)
 
     def _parse_iref(self, box: Box):
-        logger.debug("HEIC: found 'iref' Box, skipped")
-        pass
+        logger.debug("HEIC: found 'iref' Box %s, skipped", box.name)
 
     def find_exif(self) -> tuple:
         ftyp = self.expect_parse('ftyp')
@@ -304,7 +301,7 @@ class HEICExifFinder:
         meta = self.expect_parse('meta')
         assert meta.subs['iinf'].exif_infe is not None
         item_id = meta.subs['iinf'].exif_infe.item_id
-        extents = meta.subs['iloc'].locs[item_id]       
+        extents = meta.subs['iloc'].locs[item_id]
         logger.debug('HEIC: found Exif location.')
         # we expect the Exif data to be in one piece.
         assert len(extents) == 1
@@ -319,15 +316,15 @@ class HEICExifFinder:
         exif_tiff_header_offset = self.get32()
 
         if exif_tiff_header_offset == 0:
-            """ This case was found in HMD Nokia 8.3 5G heic photos.
-                The TIFF header just sits there without any 'Exif'.
-            """    
+            # This case was found in HMD Nokia 8.3 5G heic photos.
+            # The TIFF header just sits there without any 'Exif'.
+
             offset = 0
             endian = '?' # Haven't got Endian info yet
-        else:    
+        else:
             assert exif_tiff_header_offset >= 6
-            assert self.get(exif_tiff_header_offset)[-6:] == b'Exif\x00\x00'            
+            assert self.get(exif_tiff_header_offset)[-6:] == b'Exif\x00\x00'
             offset = self.file_handle.tell()
-            endian = self.file_handle.read(1)
-            
+            endian = str(self.file_handle.read(1))
+
         return offset, endian

--- a/exifread/heic.py
+++ b/exifread/heic.py
@@ -164,6 +164,12 @@ class HEICExifFinder:
             'infe': self._parse_infe,
             'iinf': self._parse_iinf,
             'iloc': self._parse_iloc,
+            'hdlr': self._parse_hdlr,  # HEIC/AVIF hdlr = Handler
+            'pitm': self._parse_pitm,  # HEIC/AVIF pitm = Primary Item
+            'iref': self._parse_iref,  # HEIC/AVIF idat = Item Reference
+            'idat': self._parse_idat,  # HEIC/AVIF idat = Item Data Box
+            'dinf': self._parse_dinf,  # HEIC/AVIF dinf = Data Information Box
+            'iprp': self._parse_iprp,  # HEIC/AVIF iprp = Item Protection Box
         }
         return defs.get(box.name)
 
@@ -256,6 +262,40 @@ class HEICExifFinder:
                 extent_length = self.get_int(box.length_size)
                 extents.append((extent_offset, extent_length))
             box.locs[item_id] = extents
+
+    """ Added a few box names, which as unhandled aborted data extraction:
+          hdlr, pitm, dinf, iprp, idat, iref
+        Handling is initially NONE.
+        They were found in .heif photo files produced by Nokia 8.3 5G.
+        They are part of the standrd, referring to:
+            - ISO/IEC 14496-12 fifth edition 2015-02-20 (chapter 8.10 Metadata)
+              found in: https://mpeg.chiariglione.org/standards/mpeg-4/iso-base-media-file-format/text-isoiec-14496-12-5th-edition
+              (The newest is ISO/IEC 14496-12:2022, but would cost 208 Swiss Francs at iso.org)
+            - A C++ example: https://exiv2.org/book/#BMFF
+    """
+    def _parse_hdlr(self, box: Box):
+        logger.debug("HEIC: encountered 'hdlr' Box, did nothing")
+        pass
+
+    def _parse_pitm(self, box: Box):
+        logger.debug("HEIC: encountered 'pitm' Box, did nothing")
+        pass
+
+    def _parse_dinf(self, box: Box):
+        logger.debug("HEIC: encountered 'dinf' Box, did nothing")
+        pass
+
+    def _parse_iprp(self, box: Box):
+        logger.debug("HEIC: encountered 'iprp' Box, did nothing")
+        pass
+
+    def _parse_idat(self, box: Box):
+        logger.debug("HEIC: encountered 'idat' Box, did nothing")
+        pass
+
+    def _parse_iref(self, box: Box):
+        logger.debug("HEIC: encountered 'iref' Box, did nothing")
+        pass
 
     def find_exif(self) -> tuple:
         ftyp = self.expect_parse('ftyp')


### PR DESCRIPTION
Exifread exceptioned (crashed) when encountering undetected HEIC tags in .heif files produced by my HMD Nokia 8.3 5G mobile phone camera. Digging in to hex, I also found out that in some files, the metadata is missing 'Exif' before TIFF header near the end of file.

My initial solution is to:
- Add dummy handling for encountered HEIC box names (which are also part of standard); in heic.py , those _parse functions
- If EXIF data is pointed to a location where TIFF header offset is 0, accept that, and check if the TIFF header just sits there
- Add to exifread/__init__.py _find_heic_tiff
- Start with minimal changes

The good it that the my .heif files that used to crash don't crash exifread any more.
The bad it that at the moment looks like it still extracts less metadata from heic files than jpg files.

I entered this, because I have a project - fotofiler - of making a Python app that copies and sorts files according to metadata, and I'm using exifread there.