### PR TITLE
ignore unknown parsers. fix #160

### DIFF
--- a/exifread/heic.py
+++ b/exifread/heic.py
@@ -20,8 +20,6 @@ logger = get_logger()
 
 class WrongBox(Exception):
     pass
-class NoParser(Exception):
-    pass
 class BoxVersion(Exception):
     pass
 class BadSize(Exception):
@@ -167,10 +165,7 @@ class HEICExifFinder:
             'iinf': self._parse_iinf,
             'iloc': self._parse_iloc,
         }
-        try:
-            return defs[box.name]
-        except (IndexError, KeyError) as err:
-            raise NoParser(box.name) from err
+        return defs.get(box.name)
 
     def parse_box(self, box: Box) -> Box:
         probe = self.get_parser(box)


### PR DESCRIPTION
Trying to parse exif data from a HEIC file leads to error:

```
  File "/Users/herbert/Library/Caches/pypoetry/virtualenvs/cux-base-mqrrDLXf-py3.10/lib/python3.10/site-packages/exifread/heic.py", line 173, in get_parser
    raise NoParser(box.name) from err
exifread.heic.NoParser: hdlr
```


I have found a commit which was meant to just add typing, but changed the behavior from just ignoring unknown parsers to throwing an exception. Just ignoring unknown parsers and skip that "box" seems to work for me.

https://github.com/ianare/exif-py/commit/d0654ca4bd3b32ed890628a02d68fa7da37098d4#diff-24bbe7a21b2cb2816c8159fdf4930992d0458647adda5b84ce5a9f8e2af24997L133-L136

before returns `None`:
```
        method = 'parse_%s' % box.name
        return getattr(self, method, None)
```

after throws an error:
```
        try:
            return defs[box.name]
        except IndexError:
            raise NoParser(box.name)
```