### PR TITLE
Make CI pass

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -14,15 +14,15 @@ jobs:
       matrix:
         python-version: ["3.8"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-dev-${{ hashFiles('setup.py') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,22 +14,21 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.5"
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-test-${{ hashFiles('setup.py') }}

--- a/exifread/classes.py
+++ b/exifread/classes.py
@@ -496,14 +496,14 @@ class ExifHeader:
             self.dump_ifd(0, 'MakerNote', tag_dict=makernote.apple.TAGS)
             self.offset = offset
             return
-        
+
         if make == 'DJI':
             offset = self.offset
             self.offset += note.field_offset
             self.dump_ifd(0, 'MakerNote', tag_dict=makernote.dji.TAGS)
             self.offset = offset
             return
-        
+
         # Canon
         if make == 'Canon':
             self.dump_ifd(note.field_offset, 'MakerNote',


### PR DESCRIPTION
Updates to make CI work:
- Removes Python 3.5/3.6 which were no longer available in `ubuntu-latest`
- Adds Python 3.11
- Specifies cache v3