### PR TITLE
CI: Update actions, test Python 3.12, run weekly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,12 +4,15 @@
 name: Test
 
 on:
-  - pull_request
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   pytest:
     name: Run Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
       matrix:
@@ -20,11 +23,13 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
+
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"


### PR DESCRIPTION
A bit of maintenance on the CI:
- Update the used actions to their latest versions
- Removes Python 3.6 (has been end-of-life for over 2 years) and add Python 3.12.
- Run once a week on the default branch (to make sure dependency updates don't break anything)