### PR TITLE
don't let debug logging trigger an exception

### DIFF
--- a/exifread/__init__.py
+++ b/exifread/__init__.py
@@ -144,12 +144,14 @@ def process_file(fh: BinaryIO, stop_tag=DEFAULT_STOP_TAG,
 
     endian = chr(ord_(endian[0]))
     # deal with the EXIF info we found
-    logger.debug("Endian format is %s (%s)", endian, {
+    endian_readable = {
         'I': 'Intel',
         'M': 'Motorola',
         '\x01': 'Adobe Ducky',
         'd': 'XMP/Adobe unknown'
-    }[endian])
+    }
+    logger.debug("Endian format is %s (%s)", endian,
+                 endian_readable.get(endian, "Unknown"))
 
     hdr = ExifHeader(fh, endian, offset, fake_exif, strict, debug, details, truncate_tags)
     ifd_list = hdr.list_ifd()


### PR DESCRIPTION
This addresses #188.  I don't have the rights to the image I've been testing with (a webp image with no exif data at all), but I'm trying to generate one I can upload to https://github.com/ianare/exif-samples.