### PR TITLE
Fix broken automated tests by syncing with exif-samples

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@
 name: Test
 
 on:
+  - push
   - pull_request
 
 jobs:
@@ -46,9 +47,8 @@ jobs:
 
     - name: Run in debug and color mode
       run: |
-        find exif-samples-master -name *.tiff -o -name *.jpg -o -name *.heif | xargs EXIF.py -dc
+        make run
 
     - name: Compare image processing output
       run: |
-        find exif-samples-master -name *.tiff -o -name *.jpg -o -name *.heif | sort -f | xargs EXIF.py > exif-samples-master/dump_test
-        diff -Z --side-by-side --suppress-common-lines exif-samples-master/dump exif-samples-master/dump_test
+        make compare

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ else
 	PIP_INSTALL := $(PIP_BIN) install --progress-bar=off
 endif
 
+# Find images, support multiple case insensitive extensions and file names with spaces, consistently sort files
+FIND_IMAGES := find exif-samples-master -regextype posix-egrep -iregex ".*\.(bmp|gif|heic|heif|jpg|jpeg|png|tiff|webp)" -print0 | LC_COLLATE=C sort -fz | xargs -0
+
 .PHONY: help
 all: help
 
@@ -41,6 +44,13 @@ samples-download: ## Install sample files used for testing.
 	wget https://github.com/ianare/exif-samples/archive/master.tar.gz
 	tar -xzf master.tar.gz
 
+run: ## Run EXIF.py on sample images
+	$(FIND_IMAGES) EXIF.py -dc
+
+compare: ## Run and compare exif dump
+	$(FIND_IMAGES) EXIF.py > exif-samples-master/dump_test
+	diff -Zu --color --suppress-common-lines exif-samples-master/dump exif-samples-master/dump_test
+
 build:  ## build distribution
 	rm -fr ./dist
 	$(PYTHON_BIN) setup.py sdist bdist_wheel
@@ -53,4 +63,4 @@ help: Makefile
 	@echo "Choose a command to run:"
 	@echo
 	@grep --no-filename -E '^[a-zA-Z_%-]+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf " \033[36m%-30s\033[0m %s\n", $$1, $$2}'
-	@echo 
+	@echo


### PR DESCRIPTION
This PR addresses the automated tests that were broken primarily due to an out-of-sync dump file in the exif-samples repository. It ensures the commands used to run the tests in exifread are consistent with those in the exif-samples repository.

Please note that the tests in this PR will not pass until the following related PRs are merged:

[PR #12 in exif-samples](https://github.com/ianare/exif-samples/pull/12) - to update the dump file and simplify future updates.
[PR #173](https://github.com/ianare/exif-py/pull/173) and [PR #196](https://github.com/ianare/exif-py/pull/196) - to fix issues in exifread when parsing HEIF files.
Additionally, I recommend including the CI maintenace changes from [PR #195](https://github.com/ianare/exif-py/pull/195).

I have verified that all tests pass when these changes are merged in a separate branch: [Successful test run](https://github.com/EtiennePelletier/exif-py/actions/runs/10998484878).

I welcome any feedback or suggestions on these changes!

# 🐍 🤹‍♂️ 