### PR TITLE
Fix KeyError in EXIF endian logging

### DIFF
--- a/exifread/__init__.py
+++ b/exifread/__init__.py
@@ -144,13 +144,16 @@ def process_file(fh: BinaryIO, stop_tag=DEFAULT_STOP_TAG,
 
     endian = chr(ord_(endian[0]))
     # deal with the EXIF info we found
-    logger.debug("Endian format is %s (%s)", endian, {
-        'I': 'Intel',
-        'M': 'Motorola',
-        '\x01': 'Adobe Ducky',
-        'd': 'XMP/Adobe unknown'
-    }[endian])
-
+    logger.debug(
+        "Endian format is %s (%s)", 
+        endian, 
+        {
+            'I': 'Intel',
+            'M': 'Motorola',
+            '\x01': 'Adobe Ducky',
+            'd': 'XMP/Adobe unknown'
+        }.get(endian, 'Unknown')  # Use .get() with default
+    )
     hdr = ExifHeader(fh, endian, offset, fake_exif, strict, debug, details, truncate_tags)
     ifd_list = hdr.list_ifd()
     thumb_ifd = 0


### PR DESCRIPTION
I use photorec sorter which has a dependency on exifread. 
I encountered the following error, which terminates the script:
`Traceback (most recent call last):
  File "/home/mark/.cache/pipx/9a3aa75b1aae148/bin/photorec_sorter", line 8, in <module>
    sys.exit(main_cli())
             ~~~~~~~~^^
  File "/home/mark/.cache/pipx/9a3aa75b1aae148/lib/python3.13/site-packages/photorec_sorter/cli.py", line 83, in main_cli
    sort_photorec_folder(
    ~~~~~~~~~~~~~~~~~~~~^
        source=args.source,
        ^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
        min_event_delta_days=args.min_event_delta,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/mark/.cache/pipx/9a3aa75b1aae148/lib/python3.13/site-packages/photorec_sorter/recovery.py", line 92, in sort_photorec_folder
    exifTags = exifread.process_file(image, details=False)
  File "/home/mark/.cache/pipx/9a3aa75b1aae148/lib/python3.13/site-packages/exifread/__init__.py", line 147, in process_file
    logger.debug("Endian format is %s (%s)", endian, {
                                                     ~
    ...<3 lines>...
        'd': 'XMP/Adobe unknown'
        ~~~~~~~~~~~~~~~~~~~~~~~~
    }[endian])
    ~^^^^^^^^
KeyError: 'E'`

I Updated logging for endian format to use `.get()` with a default value. This should prevent crashes when encountering unrecognized endian values (e.g., 'E').