### PR TITLE
This commit fixes the error as described in issue

### DIFF
--- a/exifread/heic.py
+++ b/exifread/heic.py
@@ -164,6 +164,10 @@ class HEICExifFinder:
             'infe': self._parse_infe,
             'iinf': self._parse_iinf,
             'iloc': self._parse_iloc,
+            'hdlr':None,
+            'pitm':None,
+            'iref':None,
+            'iprp':None,
         }
         return defs.get(box.name)
 


### PR DESCRIPTION
https://github.com/ianare/exif-py/issues/203 where certain box names were not being handled but having skipped it would have generated a valid output