### PR TITLE
Exclude tests directory to be installed in python site libs directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,9 @@ Changelog = "https://github.com/ianare/exif-py/blob/master/ChangeLog.rst"
 "EXIF.py" = "exifread.cli:main"
 
 
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools.packages.find]
+include = ["exifread"]
+exclude = ["tests"]
 
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
It prevents conflicts with other Python libs that erroneously install `tests` directory in Python site lib directory.