### PR TITLE
OpenDroneMap support

### DIFF
--- a/exifread/__init__.py
+++ b/exifread/__init__.py
@@ -111,7 +111,7 @@ def process_file(
             pass
 
     # extract thumbnails
-    if details and thumb_ifd and extract_thumbnail:
+    if thumb_ifd and extract_thumbnail:
         hdr.extract_tiff_thumbnail(thumb_ifd)
         hdr.extract_jpeg_thumbnail()
 

--- a/exifread/__init__.py
+++ b/exifread/__init__.py
@@ -54,6 +54,7 @@ def process_file(
     auto_seek=True,
     extract_thumbnail=True,
     builtin_types=False,
+    ignore_makernote_errors=False,
 ) -> Dict[str, Any]:
     """
     Process an image file (expects an open file object).
@@ -107,8 +108,11 @@ def process_file(
     if details and 'EXIF MakerNote' in hdr.tags and 'Image Make' in hdr.tags:
         try:
             hdr.decode_maker_note()
-        except:
-            pass
+        except Exception as e:
+            if ignore_makernote_errors:
+                logger.debug("Failed to decode EXIF MakerNote")
+            else:
+                raise e
 
     # extract thumbnails
     if thumb_ifd and extract_thumbnail:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 keywords = ["exif", "image", "metadata", "photo"]
 authors = [
-  {name = "Ianaré Sévi"}
+  {name = "Ianaré Sévi"},
 ]
 dependencies = []
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 
 [project]
-name = "ODMExifRead"
+name = "ExifRead"
 description = "Library to extract Exif information from digital camera image files."
 readme = "README.rst"
 license = {file = "LICENSE"}
@@ -21,8 +21,7 @@ classifiers = [
 ]
 keywords = ["exif", "image", "metadata", "photo"]
 authors = [
-  {name = "Ianaré Sévi"},
-  {name = "Piero Toffanin", email = "pt@masseranolabs.com"}
+  {name = "Ianaré Sévi"}
 ]
 dependencies = []
 dynamic = ["version"]
@@ -40,8 +39,8 @@ test = [
 
 
 [project.urls]
-Repository = "https://github.com/OpenDroneMap/exif-py"
-Changelog = "https://github.com/OpenDroneMap/exif-py/blob/master/ChangeLog.rst"
+Repository = "https://github.com/ianare/exif-py"
+Changelog = "https://github.com/ianare/exif-py/blob/master/ChangeLog.rst"
 
 
 [project.scripts]

--- a/tests/test_process_file.py
+++ b/tests/test_process_file.py
@@ -17,6 +17,14 @@ def test_corrupted_exception():
         assert "tag 0x089C" in str(err.value)
 
 
+def test_corrupted_ignored_exception():
+    file_path = RESOURCES_ROOT / "jpg/corrupted.jpg"
+    with open(file_path, "rb") as fh:
+        tags = exifread.process_file(fh=fh, strict=True, ignore_makernote_errors=True)
+    assert "EXIF Contrast" in tags
+    assert len(tags) == 53
+
+
 def test_corrupted_pass():
     file_path = RESOURCES_ROOT / "jpg/corrupted.jpg"
     with open(file_path, "rb") as fh:


### PR DESCRIPTION
OpenDroneMap currently has its own [fork](https://github.com/OpenDroneMap/exif-py) that [silently ignores exceptions](https://github.com/ianare/exif-py/compare/develop...NathanMOlson:ODM?expand=1) in `decode_maker_note()`. I'd like to add this behavior, behind a flag that defaults to `False`, so that ODM will not need to maintain a custom fork.