### PR TITLE
Handle malformed HEIC box types and invalid thumbnail offsets

### DIFF
--- a/exifread/core/exif_header.py
+++ b/exifread/core/exif_header.py
@@ -469,19 +469,25 @@ class ExifHeader:
         thumb_offset = self.tags.get("Thumbnail JPEGInterchangeFormat")
         thumb_length = self.tags.get("Thumbnail JPEGInterchangeFormatLength")
         if thumb_offset and thumb_length:
-            self.file_handle.seek(self.offset + thumb_offset.values[0])
-            size = thumb_length.values[0]
-            self.tags["JPEGThumbnail"] = self.file_handle.read(size)
+            try:
+                self.file_handle.seek(self.offset + thumb_offset.values[0])
+                size = thumb_length.values[0]
+                self.tags["JPEGThumbnail"] = self.file_handle.read(size)
+            except TypeError:
+                logger.debug("Invalid JPEG thumbnail offset or length, skipping")
 
         # Sometimes in a TIFF file, a JPEG thumbnail is hidden in the MakerNote
         # since it's not allowed in a uncompressed TIFF IFD
         if "JPEGThumbnail" not in self.tags:
             thumb_offset = self.tags.get("MakerNote JPEGThumbnail")
             if thumb_offset:
-                self.file_handle.seek(self.offset + thumb_offset.values[0])
-                self.tags["JPEGThumbnail"] = self.file_handle.read(
-                    thumb_offset.field_length
-                )
+                try:
+                    self.file_handle.seek(self.offset + thumb_offset.values[0])
+                    self.tags["JPEGThumbnail"] = self.file_handle.read(
+                        thumb_offset.field_length
+                    )
+                except TypeError:
+                    logger.debug("Invalid MakerNote thumbnail offset, skipping")
 
     def decode_maker_note(self) -> None:
         """

--- a/exifread/core/heic.py
+++ b/exifread/core/heic.py
@@ -160,7 +160,13 @@ class HEICExifFinder:
     def next_box(self) -> Box:
         pos = self.file_handle.tell()
         size = self.get32()
-        kind = self.get(4).decode("ascii")
+        raw = self.get(4)
+        try:
+            kind = raw.decode("ascii")
+        except UnicodeDecodeError:
+            raise InvalidExif(
+                "Invalid HEIC box type at offset %d: %r" % (pos, raw)
+            )
         box = Box(kind)
         if size == 0:
             # signifies 'to the end of the file', we shouldn't see this.


### PR DESCRIPTION
Fixes two crashes that happen when `process_file` encounters malformed image files:

**1. HEIC files with non-ASCII box types (#245)**

`HEICExifFinder.next_box()` calls `self.get(4).decode("ascii")` on the raw box type bytes, which blows up with `UnicodeDecodeError` if a byte is outside the ASCII range. This now catches the decode error and raises `InvalidExif` instead, which `process_file` already knows how to handle.

**2. JPEG files with non-integer thumbnail offsets (#247)**

`extract_jpeg_thumbnail()` does `self.offset + thumb_offset.values[0]`, but if the EXIF tag stores a non-integer value (like a tuple), this raises `TypeError`. Added a try/except around the thumbnail extraction so a bad offset just gets skipped with a debug log message.

Both cases previously let unhandled exceptions escape `process_file`, crashing any application that parses untrusted images. All existing tests pass.
