### PR TITLE
fix: Ratio.decimal() raises ZeroDivisionError when denominator is 0

### DIFF
--- a/exifread/utils.py
+++ b/exifread/utils.py
@@ -80,4 +80,6 @@ class Ratio(Fraction):
         return self.denominator
 
     def decimal(self) -> float:
+        if self.denominator == 0:
+            return float("nan")
         return float(self)

--- a/tests/test_process_file.py
+++ b/tests/test_process_file.py
@@ -1,12 +1,14 @@
 """Basic tests."""
 
 import logging
+import math
 from pathlib import Path
 
 import pytest
 
 import exifread
 from exifread import DEFAULT_STOP_TAG
+from exifread.utils import Ratio
 
 RESOURCES_ROOT = Path(__file__).parent / "resources"
 
@@ -153,6 +155,12 @@ def test_builtin_types(stop_tag, details, truncate_tags):
     assert tags["Image Make"] == "Canon"
     # Unknown / Undefined
     assert tags["EXIF FlashPixVersion"] == "0100"
+
+
+def test_ratio_decimal_zero_denominator():
+    """Ratio.decimal() returns nan (not ZeroDivisionError) when denominator is 0."""
+    r = Ratio(0, 0)
+    assert math.isnan(r.decimal())
 
 
 def test_xmp_no_tag():


### PR DESCRIPTION
## Summary

Fixes #192.

`Ratio.decimal()` delegates to `float(self)`, which calls `Fraction.__float__`
and performs `int(numerator) / int(denominator)`. When the denominator is `0`
(e.g. GPS fields stored as `0/0` by devices with GPS disabled), this raises
`ZeroDivisionError` instead of returning a value.

**Reproduction:**

```python
from exifread.utils import Ratio

Ratio(0, 0).decimal()  # ZeroDivisionError: division by zero
```

**Fix:** override `decimal()` to return `float("nan")` when `denominator == 0`.
`nan` propagates naturally through the `_degrees_to_decimal` arithmetic and
correctly signals that the raw EXIF rational was undefined, rather than silently
returning a garbage coordinate.

The change is a two-line guard in `exifread/utils.py`; a matching unit test is
added to `tests/test_process_file.py`.

---

This pull request was prepared with the assistance of AI, under my direction and review.