### PR TITLE
Don't crash on a truncated JPEG/EXIF header

### DIFF
--- a/exifread/__init__.py
+++ b/exifread/__init__.py
@@ -78,6 +78,10 @@ def process_file(
         logger.debug(err)
         return {}
 
+    if not endian_bytes:
+        logger.debug("Invalid EXIF: endian marker missing (truncated header)")
+        return {}
+
     endian_str, endian_type = get_endian_str(endian_bytes)
     # deal with the EXIF info we found
     logger.debug("Endian format is %s (%s)", endian_str, endian_type)

--- a/exifread/core/jpeg.py
+++ b/exifread/core/jpeg.py
@@ -15,13 +15,20 @@ def _increment_base(data, base) -> int:
 
 def _get_initial_base(fh: BinaryIO, data: bytes, fake_exif: int) -> Tuple[int, int]:
     base = 2
+    if len(data) < 6:
+        # Too short to hold an APP0/JFIF header; nothing to skip.
+        return base, fake_exif
     logger.debug(
         "data[2]=0x%X data[3]=0x%X data[6:10]=%s",
         ord_(data[2]),
         ord_(data[3]),
         data[6:10],
     )
-    while ord_(data[2]) == 0xFF and data[6:10] in (b"JFIF", b"JFXX", b"OLYM", b"Phot"):
+    while (
+        len(data) >= 6
+        and ord_(data[2]) == 0xFF
+        and data[6:10] in (b"JFIF", b"JFXX", b"OLYM", b"Phot")
+    ):
         length = ord_(data[4]) * 256 + ord_(data[5])
         logger.debug(" Length offset is %s", length)
         fh.read(length - 8)
@@ -43,6 +50,10 @@ def _get_base(base: int, data: bytes) -> int:
     # pylint: disable=too-many-statements
     while True:
         logger.debug(" Segment base 0x%X", base)
+        if base + 4 > len(data):
+            # Truncated JPEG: not enough bytes left for another segment
+            # header, so there is no readable EXIF here.
+            raise InvalidExif("Truncated JPEG data while scanning for EXIF")
         if data[base : base + 2] == b"\xff\xe1":
             # APP1
             logger.debug("  APP1 at base 0x%X", base)

--- a/tests/test_process_file.py
+++ b/tests/test_process_file.py
@@ -1,5 +1,6 @@
 """Basic tests."""
 
+import io
 import logging
 from pathlib import Path
 
@@ -165,3 +166,17 @@ def test_xmp_no_tag():
             builtin_types=True,
         )
     assert len(tags["Image ApplicationNotes"]) == 323
+
+
+def test_truncated_headers_do_not_crash():
+    # A JPEG/EXIF/TIFF header that ends partway through must yield no tags
+    # rather than raising IndexError from an unchecked byte read.
+    truncated = [
+        bytes.fromhex('ffd8'),  # SOI only
+        bytes.fromhex('ffd8ffe1'),  # APP1 marker, no length
+        bytes.fromhex('ffd8ffe10008') + b'Exif' + bytes.fromhex('0000'),  # cut before endian
+        bytes.fromhex('ffd8ffe00010') + b'JFIF' + bytes.fromhex('00'),  # truncated APP0/JFIF
+        b'II*' + bytes.fromhex('0008000000'),  # TIFF header, empty IFD
+    ]
+    for data in truncated:
+        assert exifread.process_file(io.BytesIO(data)) == {}


### PR DESCRIPTION
`process_file` raises a bare `IndexError` on a JPEG whose headers are cut short, instead of returning no tags the way it already does for a file that simply has no EXIF.

```python
import io, exifread
exifread.process_file(io.BytesIO(b"\xff\xd8\xff\xe1\x00\x08Exif\x00\x00"))
# IndexError: index out of range
```

I found this while feeding partial/garbled image data through `process_file` and hit it from three different unchecked reads, depending on where the data ends:

- `get_endian_str` indexes `endian_bytes[0]` when the endian marker is missing (the stream ends right after the `Exif` prefix).
- `_get_base` reads the segment length past the end of the buffer while scanning for the APP1 segment.
- `_get_initial_base` reads `data[2]` / `data[6:10]` on a buffer shorter than an APP0 header (for example a bare `\xff\xd8`).

Each is guarded here: a missing endian marker and a truncated segment scan are treated as invalid EXIF (return no tags / raise `InvalidExif`, which `process_file` already turns into an empty result), and `_get_initial_base` returns early and bounds-checks its loop. Valid files are unaffected.

To confirm it is not whack-a-mole, I truncated a small EXIF JPEG at every length, plus a JFIF JPEG and assorted garbage, and none of them raise now; a real EXIF file still parses to the same tags. Added `test_truncated_headers_do_not_crash` covering the three truncation points, and the full suite passes (32 tests).