### PR TITLE
Don't crash on a malformed HEIC file

### DIFF
--- a/exifread/__init__.py
+++ b/exifread/__init__.py
@@ -5,7 +5,7 @@ Supported formats: TIFF, JPEG, PNG, Webp, HEIC
 
 from typing import Any, BinaryIO, Dict
 
-from exifread.core.exceptions import ExifNotFound, InvalidExif
+from exifread.core.exceptions import ExifError, ExifNotFound, InvalidExif
 from exifread.core.exif_header import ExifHeader
 from exifread.core.find_exif import determine_type, get_endian_str
 from exifread.core.xmp import find_xmp_data
@@ -74,7 +74,7 @@ def process_file(
     except ExifNotFound as err:
         logger.warning(err)
         return {}
-    except InvalidExif as err:
+    except ExifError as err:
         logger.debug(err)
         return {}
 

--- a/exifread/core/heic.py
+++ b/exifread/core/heic.py
@@ -113,7 +113,7 @@ class HEICExifFinder:
     def get(self, nbytes: int) -> bytes:
         read = self.file_handle.read(nbytes)
         if not read:
-            raise EOFError
+            raise BadSize("unexpected end of file")
         if len(read) != nbytes:
             msg = "get(nbytes={nbytes}) found {read} bytes at position {pos}".format(
                 nbytes=nbytes, read=len(read), pos=self.file_handle.tell()
@@ -163,8 +163,10 @@ class HEICExifFinder:
         kind = self.get(4).decode("ascii")
         box = Box(kind)
         if size == 0:
-            # signifies 'to the end of the file', we shouldn't see this.
-            raise NotImplementedError
+            # A size of 0 means 'box extends to the end of the file'. This box
+            # walker needs an explicit length, so treat it as a bad size rather
+            # than raising a bare NotImplementedError that escapes process_file.
+            raise BadSize(size)
         if size == 1:
             # 64-bit size follows type.
             size = self.get64()

--- a/tests/test_process_file.py
+++ b/tests/test_process_file.py
@@ -165,3 +165,25 @@ def test_xmp_no_tag():
             builtin_types=True,
         )
     assert len(tags["Image ApplicationNotes"]) == 323
+
+
+def test_malformed_heic_does_not_crash():
+    # A HEIC/ISO-BMFF box with an unsupported size (0 or the 64-bit form) or
+    # one that runs past the end of the file must yield no tags, not a bare
+    # NotImplementedError / EOFError escaping process_file.
+    import io
+    import struct
+
+    def box(kind, payload=b""):
+        return struct.pack(">I", 8 + len(payload)) + kind + payload
+
+    ftyp = box(b"ftyp", b"heic" + struct.pack(">I", 0) + b"heic")
+    cases = [
+        ftyp + struct.pack(">I", 0) + b"meta" + b"\x00" * 4,
+        ftyp + struct.pack(">I", 0xFFFFFFFF) + b"meta" + b"\x00" * 4,
+        ftyp + struct.pack(">I", 1) + b"meta",
+        ftyp,
+        box(b"ftyp", b"heic"),
+    ]
+    for data in cases:
+        assert exifread.process_file(io.BytesIO(data)) == {}


### PR DESCRIPTION
`process_file` on a malformed HEIC can escape with an exception it doesn't handle, so the caller crashes instead of getting an empty result the way it does for other unreadable images:

```python
import io, struct, exifread
def box(k, p=b""): return struct.pack(">I", 8 + len(p)) + k + p
ftyp = box(b"ftyp", b"heic" + struct.pack(">I", 0) + b"heic")

exifread.process_file(io.BytesIO(ftyp + struct.pack(">I", 0) + b"meta" + b"\x00" * 4))
# NotImplementedError            (a box with size 0)
exifread.process_file(io.BytesIO(ftyp))
# EOFError                       (a box that runs past the end of the file)
```

The HEIC reader raises a few things `process_file` doesn't catch: a bare `NotImplementedError` for a size-0 box, `EOFError` from `get()` at end of file, and `BadSize` / `BoxVersion` (which subclass `ExifError` but not `InvalidExif`).

This keeps everything inside exif-py's own error hierarchy and handles it in one place:

- `next_box` raises `BadSize` for a size-0 box instead of `NotImplementedError`.
- `get()` raises `BadSize` on an unexpected end of file instead of `EOFError`.
- `process_file` catches the base `ExifError`, so `ExifNotFound`, `InvalidExif`, `BadSize` and `BoxVersion` all yield an empty result.

Valid files are unaffected (the existing suite passes, 32). Added a test with several malformed HEIC inputs. This is separate from the non-ASCII box-type case in #245 (that raises `UnicodeDecodeError`, addressed in #253).